### PR TITLE
Switch to Building Hive Metastore 4.0.0 from Source

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_IMAGE_TAG=17-jdk-noble
 ARG BUILD_ENV=templates
-ARG HMS_VERSION=3.0.0
+ARG HIVE_VERSION=4.0.0
 ARG HADOOP_VERSION=3.4.1
 ARG MYSQL_CONNECTOR_VERSION=9.1.0
 ARG LOG4J_VERIONS=2.24.1
@@ -46,10 +46,28 @@ RUN . /usr/local/bin/verlte && \
 RUN mvn dependency:copy-dependencies -DoutputDirectory=/build/dependencies
 
 
+FROM maven:3-eclipse-temurin-8-focal AS hms-builder
+ARG HIVE_VERSION
+
+WORKDIR /hive
+# Hive 4.0.0 need patch. Root cause: HIVE-28487, solved in Hive 4.0.1
+RUN wget https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-src.tar.gz && \
+    tar -xzf apache-hive-${HIVE_VERSION}-src.tar.gz && \
+    rm apache-hive-${HIVE_VERSION}-src.tar.gz && \
+    cd apache-hive-${HIVE_VERSION}-src/standalone-metastore && \
+    if [ "${HIVE_VERSION}" = "4.0.0" ]; then \
+        sed -i 's/CLASS=org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool/CLASS=org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool/' \
+            metastore-server/src/main/scripts/ext/schemaTool.sh; \
+    fi && \
+    mvn clean install -DskipTests -Pdist && \
+    mv metastore-server/target/apache-hive-standalone-metastore-server-${HIVE_VERSION}-bin.tar.gz \
+        /hive/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz
+
+
 # Continue from the selected template stage
 FROM build_${BUILD_ENV} AS build
 
-ARG HMS_VERSION
+ARG HIVE_VERSION
 ARG HADOOP_VERSION
 ARG MYSQL_CONNECTOR_VERSION
 ARG LOG4J_VERIONS
@@ -100,10 +118,10 @@ RUN tar -xzf hadoop-${HADOOP_VERSION}*.tar.gz && \
 
 
 # Download and install Hive Metastore Standalone (HMS)
-RUN wget https://downloads.apache.org/hive/hive-standalone-metastore-${HMS_VERSION}/hive-standalone-metastore-${HMS_VERSION}-bin.tar.gz && \
-    tar -xzf hive-standalone-metastore-${HMS_VERSION}-bin.tar.gz && \
-    rm hive-standalone-metastore-${HMS_VERSION}-bin.tar.gz && \
-    mv apache-hive-metastore-${HMS_VERSION}-bin $METASTORE_HOME
+COPY --from=hms-builder /hive/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz .
+RUN tar -xzf hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz && \
+    rm hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz && \
+    mv apache-hive-metastore-${HIVE_VERSION}-bin $METASTORE_HOME
 
 
 # Add additional jars to the Hadoop classpath
@@ -114,7 +132,8 @@ RUN wget -P $LIB_DIR https://repo1.maven.org/maven2/org/apache/logging/log4j/log
     wget -P $LIB_DIR https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/${LOG4J_VERIONS}/log4j-api-${LOG4J_VERIONS}.jar && \
     wget -P $LIB_DIR https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/${LOG4J_VERIONS}/log4j-core-${LOG4J_VERIONS}.jar && \
     wget -P $LIB_DIR https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j18-impl/2.18.0/log4j-slf4j18-impl-2.18.0.jar && \
-    wget -P $LIB_DIR https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_CONNECTOR_VERSION}/mysql-connector-j-${MYSQL_CONNECTOR_VERSION}.jar -O $LIB_DIR/mysql-connector-java.jar
+    wget -P $LIB_DIR https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/${MYSQL_CONNECTOR_VERSION}/mysql-connector-j-${MYSQL_CONNECTOR_VERSION}.jar -O $LIB_DIR/mysql-connector-java.jar && \
+    wget -P $LIB_DIR https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-hdfs/${HADOOP_VERSION}/hadoop-hdfs-${HADOOP_VERSION}.jar -O $LIB_DIR/hadoop-hdfs-${HADOOP_VERSION}.jar
 
 
 RUN ln -s $LIB_DIR/mysql-connector-java* ${HADOOP_HOME}/share/hadoop/common/lib/ && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_IMAGE_TAG=17-jdk-noble
 ARG BUILD_ENV=templates
-ARG HIVE_VERSION=4.0.0
+ARG HIVE_VERSION=3.1.3
 ARG HADOOP_VERSION=3.4.1
 ARG MYSQL_CONNECTOR_VERSION=9.1.0
 ARG LOG4J_VERIONS=2.24.1
@@ -50,18 +50,25 @@ FROM maven:3-eclipse-temurin-8-focal AS hms-builder
 ARG HIVE_VERSION
 
 WORKDIR /hive
-# Hive 4.0.0 need patch. Root cause: HIVE-28487, solved in Hive 4.0.1
-RUN wget https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-src.tar.gz && \
-    tar -xzf apache-hive-${HIVE_VERSION}-src.tar.gz && \
-    rm apache-hive-${HIVE_VERSION}-src.tar.gz && \
-    cd apache-hive-${HIVE_VERSION}-src/standalone-metastore && \
-    if [ "${HIVE_VERSION}" = "4.0.0" ]; then \
-        sed -i 's/CLASS=org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool/CLASS=org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool/' \
-            metastore-server/src/main/scripts/ext/schemaTool.sh; \
-    fi && \
-    mvn clean install -DskipTests -Pdist && \
-    mv metastore-server/target/apache-hive-standalone-metastore-server-${HIVE_VERSION}-bin.tar.gz \
-        /hive/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz
+
+RUN if [ -n "${HIVE_VERSION%%3*}" ]; then \
+        echo "Building Hive ${HIVE_VERSION} from source" && \
+        wget https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-src.tar.gz && \
+        tar -xzf apache-hive-${HIVE_VERSION}-src.tar.gz && \
+        rm apache-hive-${HIVE_VERSION}-src.tar.gz && \
+        cd apache-hive-${HIVE_VERSION}-src/standalone-metastore && \
+        # Apply patch specifically for Hive 4.0.0 (HIVE-28487)
+        if [ "${HIVE_VERSION}" = "4.0.0" ]; then \
+            sed -i 's/CLASS=org.apache.hadoop.hive.metastore.tools.MetastoreSchemaTool/CLASS=org.apache.hadoop.hive.metastore.tools.schematool.MetastoreSchemaTool/' \
+                metastore-server/src/main/scripts/ext/schemaTool.sh; \
+        fi && \
+        mvn clean install -DskipTests -Pdist && \
+        mv metastore-server/target/apache-hive-standalone-metastore-server-${HIVE_VERSION}-bin.tar.gz \
+            /hive/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz; \
+    else \
+        echo "Downloading Hive ${HIVE_VERSION} pre-built package" && \
+        wget https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastore/${HIVE_VERSION}/hive-standalone-metastore-${HIVE_VERSION}-bin.tar.gz ; \
+    fi
 
 
 # Continue from the selected template stage

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,6 +39,11 @@ docker push $DOCKERHUB_USERNAME/hive-metastore:3.0.0
 ### Environment Variables
 When running the container in sidecar mode, the following environment variables are used to configure the Hive Metastore:
 
+#### Logging Configuration
+- `VERBOSE`: Enable verbose logging when set to "true" (default: false)
+  - When enabled, adds the `--verbose` flag to the metastore startup command
+  - Provides more detailed logging output for troubleshooting
+
 #### S3 Configuration (core-site.xml)
 - `HIVE_WAREHOUSE_S3LOCATION`: S3 bucket location for the warehouse (optional)
   - When set, configures the default filesystem to use S3
@@ -65,6 +70,9 @@ Required when `HIVE_DB_EXTERNAL=true`:
 
 Example environment configuration for sidecar mode:
 ```bash
+# Logging Configuration
+export VERBOSE=true
+
 # Basic Configuration
 export HIVE_WAREHOUSE_S3LOCATION=my-bucket/warehouse
 export HIVE_WAREHOUSE_DIR=/my-bucket/warehouse

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -162,12 +162,12 @@ function run_schema_tool() {
 }
 
 function start_metastore() {
+  local metastore_cmd="/opt/hive-metastore/bin/start-metastore"
   local verbose_flag=""
   if [ "${VERBOSE}" = "true" ]; then
     verbose_flag="--verbose"
   fi
 
-  local hive_start_cmd="/opt/hive-metastore/bin/start-metastore ${verbose_flag}"
   local self_terminate_cmd="/opt/hive-metastore/bin/self-terminate.sh"
 
   if [ "${ENABLE_SELF_TERMINATE}" = "true" ]; then
@@ -184,11 +184,11 @@ function start_metastore() {
     export SELF_TERMINATE_INIT_TIMEOUT
     export SELF_TERMINATE_HEARTBEAT_TIMEOUT
 
-    "$hive_start_cmd" & "$self_terminate_cmd" & wait
+    "${metastore_cmd}" ${verbose_flag} & "${self_terminate_cmd}" & wait
   else
     log "INFO" "Starting Hive Metastore service (self-terminate disabled)"
     [ "${VERBOSE}" = "true" ] && log "INFO" "- Verbose logging: enabled"
-    "$hive_start_cmd" & wait
+    "${metastore_cmd}" ${verbose_flag} & wait
   fi
 }
 

--- a/docker/templates/metastore-site.xml.tpl
+++ b/docker/templates/metastore-site.xml.tpl
@@ -30,7 +30,7 @@
 
   <property>
     <name>metastore.task.threads.always</name>
-    <value>org.apache.hadoop.hive.metastore.events.EventCleanerTask,org.apache.hadoop.hive.metastore.MaterializationsCacheCleanerTask</value>
+    <value>org.apache.hadoop.hive.metastore.events.EventCleanerTask</value>
   </property>
 
   <property>


### PR DESCRIPTION
The Hive community has stopped providing separate releases for standalone metastore to reduce release process overhead. The previously used download URL for pre-built HMS binaries is no longer available ( except 3.0.0 ). Per [community guidance](https://lists.apache.org/thread/q53hx94z132pdqoqq001mv4snoo27zcb), we need to build HMS from source.

## What Changed
- Added new `hms-builder` stage in Dockerfile to build HMS 4.0.0 from source code
- Applied patch for [HIVE-28487](https://issues.apache.org/jira/browse/HIVE-28487) in the build process (fixed in upcoming 4.0.1)
- Added missing hadoop-hdfs dependency jar
- Removed `MaterializationsCacheCleanerTask` from always-running tasks as it's not needed
- Renamed `HMS_VERSION` arg to `HIVE_VERSION` for better clarity

## Testing
- [x] Built container locally and verified HMS startup
- [x] Verified metastore connectivity
- [x] Checked schema initialization works
- [x] Validated basic metadata operations (create/read tables)

## Additional Notes
- The source build adds about 5-10 minutes to the container build time but only impacts build phase
- The patch for HIVE-28487 can be removed once we upgrade to 4.0.1
- No schema changes or client-side changes required

@melodyyangaws 