### PR TITLE
Add AWS Network Load Balancer Support for External HMS Access

### DIFF
--- a/hive-metastore-chart/templates/service.yaml
+++ b/hive-metastore-chart/templates/service.yaml
@@ -1,10 +1,14 @@
+# Service 1 - Default internal service
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "hive-metastore.name" . }}
   labels:
     {{- include "hive-metastore.labels" $ | trim | nindent 4 }}
-
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -14,3 +18,28 @@ spec:
       protocol: TCP
   selector:
     {{- include "hive-metastore.selectorLabels" . | nindent 4 }}
+
+---
+# Service 2 - LoadBalancer service
+{{- if .Values.service.nlb.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hive-metastore.name" . }}-nlb
+  labels:
+    {{- include "hive-metastore.labels" $ | trim | nindent 4 }}
+  {{- with .Values.service.nlb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: LoadBalancer
+  loadBalancerClass: service.k8s.aws/nlb
+  ports:
+    - name: thrift
+      port: 9083
+      targetPort: 9083
+      protocol: TCP
+  selector:
+    {{- include "hive-metastore.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/hive-metastore-chart/values.yaml
+++ b/hive-metastore-chart/values.yaml
@@ -27,7 +27,13 @@ env:
   # HIVE_DB_USER: <SECRET_MANAGER_SECRET_KEY_FOR_USERNAME>
   # HIVE_DB_PASS: <SECRET_MANAGER_SECRET_KEY_FOR_PASSWORD>
 service:
-  type: ClusterIP 
+  type: ClusterIP
+  annotations: {}  # For the default service
+  nlb:
+    enabled: false
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
+      service.beta.kubernetes.io/load-balancer-source-ranges: "10.0.0.0/8"  # Example CIDR
 resources:
   limits:
     cpu: 1


### PR DESCRIPTION
## Summary
This PR adds support for exposing Hive Metastore Service (HMS) externally using AWS Network Load Balancer (NLB). This feature enables access to HMS from outside the EKS cluster, supporting cross-VPC and cross-region connectivity scenarios.

## Changes
- Add optional NLB service configuration in `service.yaml`
- Update `values.yaml` with NLB configuration options and defaults
- Extend documentation with NLB setup guide and examples
- Add reference links to AWS Load Balancer Controller documentation

## Why
HMS currently only supports internal cluster access via ClusterIP. However, there are several use cases where external access is needed:
- Access HMS from applications in same or different VPCs
- Enable cross-region HMS access
- Provide stable, static DNS addresses for HMS access
- Support external clients that need to connect to HMS

## Implementation Details
1. **Service Configuration**:
   - Maintain existing ClusterIP service for internal access
   - Add optional NLB service with configurable annotations
   - Support CIDR-based access control

2. **Values Structure**:
```yaml
service:
  type: ClusterIP
  annotations: {}  # For the default service
  nlb:
    enabled: false
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
      service.beta.kubernetes.io/load-balancer-source-ranges: "10.0.0.0/8"
```

## Testing Done
 -  Tested NLB creation with default settings
 - Verified external access with specified CIDR ranges
 - Confirmed internal service continues to work with NLB enabled
 - Validated documentation examples

## Dependencies
 - Requires AWS Load Balancer Controller to be installed on the EKS cluster
 - EKS version must be >= 1.23

## Usage Example

```yaml
# Enable NLB with custom configuration
service:
  nlb:
    enabled: true
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: instance
      service.beta.kubernetes.io/load-balancer-source-ranges: "10.0.0.0/8"
```


## Documentation
 - Added NLB setup guide in README.md
 - Included links to official AWS documentation
 - Added configuration examples and best practices
 
 @melodyyangaws